### PR TITLE
Improve use of Haml

### DIFF
--- a/index.haml
+++ b/index.haml
@@ -5,10 +5,10 @@
 <html lang="en">
 <!--<![endif]-->
 %head
-  %meta{ "http-equiv" => "X-UA-Compatible", :content => "IE=edge,chrome=1" }
-  %meta{ :charset => "utf-8" }
+  %meta(http-equiv="X-UA-Compatible" content="IE=edge,chrome=1")
+  %meta(charset="utf-8")
   %title
-  %link{ :href => "css/application.css", :rel => "stylesheet" }
+  %link(href="css/application.css" rel="stylesheet")
 %body
   / Content
 </html>


### PR DESCRIPTION
Added 2 changes; firstly, properly nested the `head` and `body` tags within the `html` tag, also switched to the more terse HTML-style attribute syntax.
